### PR TITLE
fix: auto-install provider extras + silence benign SDK warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,8 @@ line-length = 120
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "UP", "B", "SIM"]
+
+[tool.uv]
+# Install all provider SDKs by default so `uv run`/`uv sync` keep them current
+# (uv otherwise syncs only base deps, leaving provider extras stale on update).
+default-extras = ["all"]

--- a/src/giga_research/cli.py
+++ b/src/giga_research/cli.py
@@ -6,9 +6,15 @@ import argparse
 import asyncio
 import json
 import sys
+import warnings
 from pathlib import Path
 
-from giga_research.config import ALL_PROVIDERS, CLIENT_REGISTRY, Config
+# The Anthropic SDK emits benign Pydantic serializer warnings while handling
+# web_search responses (a code_execution caller shape its models don't fully
+# type). They don't affect output — silence the stderr noise during runs.
+warnings.filterwarnings("ignore", message="Pydantic serializer warnings", category=UserWarning)
+
+from giga_research.config import ALL_PROVIDERS, CLIENT_REGISTRY, Config  # noqa: E402
 
 
 def _cli_error(message: str) -> None:


### PR DESCRIPTION
Two small robustness fixes:

- **`default-extras = ["all"]`** so `uv run`/`uv sync` keep the provider SDKs current. Fixes the gap where a dep bump (e.g. `google-genai>=2.0`) wasn't applied on `uv run` after an update — no more manual `uv sync --all-extras`.
- **Silence the benign Pydantic serializer warnings** the Anthropic SDK emits on web_search responses.

135 tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)